### PR TITLE
fixes Protocol version negotiation incorrect #41

### DIFF
--- a/src/Server/MCPServer.php
+++ b/src/Server/MCPServer.php
@@ -240,15 +240,8 @@ final class MCPServer implements MCPServerInterface
             return $requestedVersion;
         }
 
-        // Throw error for unsupported protocol version
-        throw new JsonRpcErrorException(
-            message: 'Unsupported protocol version',
-            code: JsonRpcErrorCode::INVALID_PARAMS,
-            data: [
-                'supported' => $supportedVersions,
-                'requested' => $requestedVersion,
-            ]
-        );
+        //return latest version
+        return MCPProtocolInterface::PROTOCOL_VERSION_STREAMABE_HTTP;
     }
 
     /**


### PR DESCRIPTION
now it works again (mcp-proxy requesting 2025-06-18 per default)


```
➜  symfony-mcp-server git:(fix-version-negatiation-issue) uvx mcp-proxy --transport streamablehttp  http://localhost:8000/mcp
[I 2025-06-30 19:33:18,292.292 httpx] HTTP Request: POST http://localhost:8000/mcp "HTTP/1.1 200 OK"
[I 2025-06-30 19:33:18,293.293 mcp.client.streamable_http] Received session ID: 6862ca5e46cde
[I 2025-06-30 19:33:18,293.293 mcp.client.streamable_http] Negotiated protocol version: 2025-03-26
[I 2025-06-30 19:33:18,300.300 httpx] HTTP Request: GET http://localhost:8000/mcp "HTTP/1.1 405 Method Not Allowed"
[I 2025-06-30 19:33:18,300.300 httpx] HTTP Request: POST http://localhost:8000/mcp "HTTP/1.1 200 OK"
``` 